### PR TITLE
Dev

### DIFF
--- a/mcp_testing/http/tester.py
+++ b/mcp_testing/http/tester.py
@@ -1061,11 +1061,11 @@ class MCPHttpTester:
                 self.initialized = False
                 
                 params = {
-                    "client_info": {
+                    "clientInfo": {  # Use camelCase as per MCP specification
                         "name": "MCP HTTP Tester",
                         "version": "1.0.0"
                     },
-                    "client_capabilities": {
+                    "clientCapabilities": {  # Use camelCase as per MCP specification
                         "protocol_versions": [version]
                     }
                 }
@@ -1467,12 +1467,11 @@ class MCPHttpTester:
         # Use different parameter names based on protocol version
         if self.protocol_version == "2025-06-18":
             params = {
-                "protocolVersion": self.protocol_version,
-                "client_info": {
+                "clientInfo": {  # Use camelCase as per MCP specification
                     "name": "MCP HTTP Tester",
                     "version": "1.0.0"
                 },
-                "client_capabilities": {
+                "clientCapabilities": {  # Use camelCase as per MCP specification
                     "protocol_versions": [self.protocol_version],
                     "tools": {"asyncSupported": True},
                     "resources": True
@@ -1481,7 +1480,7 @@ class MCPHttpTester:
         else:
             params = {
                 "protocolVersion": self.protocol_version,
-                "clientInfo": {
+                "clientInfo": {  # Use camelCase as per MCP specification
                     "name": "MCP HTTP Tester",
                     "version": "1.0.0"
                 },
@@ -1908,228 +1907,4 @@ class MCPHttpTester:
         # Reset our state even if the server didn't reset
         self.session_id = None
         self.initialized = False
-        return True
-
-    def test_status_codes(self):
-        """Test various HTTP status code scenarios."""
-        print("\n=== Testing HTTP Status Codes ===")
-        
-        tests = [
-            {
-                "name": "invalid_json",
-                "payload": "{bad json}",
-                "expected_code": 400,
-                "headers": None
-            },
-            {
-                "name": "no_method",
-                "payload": {"jsonrpc": "2.0", "id": 1},
-                "expected_code": 400,
-                "headers": None
-            },
-            {
-                "name": "unknown_method",
-                "payload": {"jsonrpc": "2.0", "id": 1, "method": "unknown_method"},
-                "expected_code": 404,
-                "headers": None
-            },
-            {
-                "name": "invalid_session",
-                "payload": {"jsonrpc": "2.0", "id": 1, "method": "initialize"},
-                "expected_code": 401,
-                "headers": {"Mcp-Session-Id": "invalid-session"}
-            }
-        ]
-        
-        success = True
-        for test in tests:
-            try:
-                response = self.request_session.post(
-                    self.url,
-                    json=test["payload"] if isinstance(test["payload"], dict) else test["payload"],
-                    headers=test["headers"] if test["headers"] else {},
-                    timeout=5
-                )
-                
-                if response.status_code == test["expected_code"]:
-                    print(f"✅ {test['name']}: Got expected status code {test['expected_code']}")
-                else:
-                    print(f"❌ {test['name']}: Expected {test['expected_code']}, got {response.status_code}")
-                    success = False
-                    
-            except Exception as e:
-                print(f"❌ {test['name']}: Test failed with error: {str(e)}")
-                success = False
-                
-        return success
-
-    def test_headers(self):
-        """Test HTTP header handling."""
-        print("\n=== Testing HTTP Headers ===")
-        
-        # Initialize first to get a valid session
-        if not self.initialize():
-            print("❌ Failed to initialize for header tests")
-            return False
-            
-        tests = [
-            {
-                "name": "content_type",
-                "required_headers": {"Content-Type": "application/json"},
-                "method": "server/info"
-            },
-            {
-                "name": "session_id_present",
-                "required_headers": {"Mcp-Session-Id": None},  # None means just check presence
-                "method": "server/info"
-            }
-        ]
-        
-        if self.protocol_version == "2025-06-18":
-            tests.append({
-                "name": "protocol_version",
-                "required_headers": {"MCP-Protocol-Version": "2025-06-18"},
-                "method": "server/info"
-            })
-            
-        success = True
-        for test in tests:
-            try:
-                status, headers, _ = self.send_request(test["method"])
-                
-                if status != 200:
-                    print(f"❌ {test['name']}: Request failed with status {status}")
-                    success = False
-                    continue
-                    
-                # Check required headers
-                headers_valid = True
-                for header, expected_value in test["required_headers"].items():
-                    header_present = False
-                    for response_header in headers:
-                        if response_header.lower() == header.lower():
-                            header_present = True
-                            if expected_value is not None and headers[response_header] != expected_value:
-                                print(f"❌ {test['name']}: Expected {header}={expected_value}, got {headers[response_header]}")
-                                headers_valid = False
-                            break
-                            
-                    if not header_present:
-                        print(f"❌ {test['name']}: Missing required header {header}")
-                        headers_valid = False
-                        
-                if headers_valid:
-                    print(f"✅ {test['name']}: All required headers present and valid")
-                else:
-                    success = False
-                    
-            except Exception as e:
-                print(f"❌ {test['name']}: Test failed with error: {str(e)}")
-                success = False
-                
-        return success
-
-    def test_protocol_versions(self):
-        """Test protocol version negotiation."""
-        print("\n=== Testing Protocol Version Negotiation ===")
-        
-        versions = ["2024-11-05", "2025-03-26", "2025-06-18"]
-        success = True
-        
-        for version in versions:
-            try:
-                params = {
-                    "client_info": {
-                        "name": "MCP HTTP Tester",
-                        "version": "1.0.0"
-                    },
-                    "client_capabilities": {
-                        "protocol_versions": [version]
-                    }
-                }
-                
-                headers = {"MCP-Protocol-Version": version} if version == "2025-06-18" else {}
-                status, response_headers, body = self.send_request("initialize", params, headers)
-                
-                if status != 200:
-                    print(f"❌ Version {version}: Initialize failed with status {status}")
-                    success = False
-                    continue
-                    
-                if not isinstance(body, dict) or "result" not in body:
-                    print(f"❌ Version {version}: Invalid response format")
-                    success = False
-                    continue
-                    
-                result = body["result"]
-                if "protocol_version" not in result:
-                    print(f"❌ Version {version}: Missing protocol_version in response")
-                    success = False
-                    continue
-                    
-                if result["protocol_version"] != version:
-                    print(f"❌ Version {version}: Server responded with different version {result['protocol_version']}")
-                    success = False
-                    continue
-                    
-                print(f"✅ Version {version}: Successfully negotiated")
-                
-            except Exception as e:
-                print(f"❌ Version {version}: Test failed with error: {str(e)}")
-                success = False
-                
-        return success
-
-    def run_all_tests(self):
-        """Run basic tests in sequence (for backwards compatibility)."""
-        try:
-            if not self.reset_server():
-                print("WARNING: Failed to reset server state, tests may fail")
-            
-            # Run existing tests
-            if not self.options_request():
-                # Don't fail the entire test suite for OPTIONS issues
-                pass
-            
-            if not self.initialize():
-                return False
-            
-            if not self.list_tools():
-                return False
-            
-            # Only run for 2025-03-26
-            if self.protocol_version == "2025-03-26" and self.get_tool_by_name("sleep"):
-                if not self.test_async_sleep_tool():
-                    return False
-            
-            if not self.test_available_tools():
-                return False
-                
-            # Run new tests
-            if not self.test_status_codes():
-                return False
-                
-            if not self.test_headers():
-                return False
-                
-            if not self.test_protocol_versions():
-                return False
-            
-            print("\n=== Test Results ===")
-            print("PASS: OPTIONS request")
-            print("PASS: Initialize")
-            print("PASS: List Tools")
-            if self.protocol_version == "2025-03-26" and self.get_tool_by_name("sleep"):
-                print("PASS: Async Sleep Tool")
-            print("PASS: Available Tools")
-            print("PASS: Status Codes")
-            print("PASS: Headers")
-            print("PASS: Protocol Versions")
-            
-            print("\nSummary: All basic tests passed")
-            return True
-        except Exception as e:
-            print(f"Error during test execution: {str(e)}")
-            import traceback
-            traceback.print_exc()
-            return False 
+        return True 

--- a/ref_http_server/reference_mcp_server.py
+++ b/ref_http_server/reference_mcp_server.py
@@ -68,23 +68,20 @@ class ServerCapabilities(BaseModel):
 
 class InitializeParams(BaseModel):
     """Parameters for initialize request."""
-    client_info: ClientInfo
-    client_capabilities: ClientCapabilities
+    client_info: ClientInfo = Field(alias="clientInfo")
+    client_capabilities: ClientCapabilities = Field(alias="clientCapabilities")
 
 class InitializeResult(BaseModel):
     """Result of initialize request."""
-    session_id: str
-    protocol_version: str
-    server_info: Dict[str, str]
-    server_capabilities: ServerCapabilities
+    session_id: str = Field(alias="sessionId")
+    protocol_version: str = Field(alias="protocolVersion")
+    server_info: Dict[str, str] = Field(alias="serverInfo")
+    server_capabilities: ServerCapabilities = Field(alias="serverCapabilities")
 
     def model_dump(self, *args, **kwargs):
-        """Override model_dump() to ensure all fields are included."""
+        """Override model_dump() to ensure proper camelCase field names."""
+        kwargs.setdefault('by_alias', True)  # Use aliases (camelCase) by default
         base_dict = super().model_dump(*args, **kwargs)
-        base_dict["server_capabilities"] = self.server_capabilities.model_dump()
-        base_dict["server_info"] = self.server_info
-        base_dict["protocol_version"] = self.protocol_version
-        base_dict["session_id"] = self.session_id
         return base_dict
 
 class JsonRpcRequest(BaseModel):
@@ -622,12 +619,12 @@ class McpReferenceServer:
                 response["result"] = {"timestamp": datetime.now().isoformat()}
             
             else:
-                # Method not found - this should return 404 per JSON-RPC over HTTP best practices
+                # Method not found - return 200 with JSON-RPC error per JSON-RPC specification
                 response["error"] = {
                     "code": -32601,  # Method not found
                     "message": f"Method not found: {method}"
                 }
-                return JSONResponse(status_code=404, content=response)  # 404 Not Found for unknown method
+                return JSONResponse(status_code=200, content=response)  # 200 OK with JSON-RPC error
             
             return JSONResponse(content=response)
             


### PR DESCRIPTION
# OAuth 2.1 Support and MCP 2025-06-18 Compliance

## Overview
This PR adds full OAuth 2.1 support to MCP-validator and implements comprehensive compliance testing for the MCP 2025-06-18 specification. It also resolves several critical issues related to authentication handling and specification compliance.

## Key Changes

### OAuth 2.1 Implementation
- Added OAuth 2.1 authentication support to MCP HTTP compliance testing
- Implemented comprehensive OAuth 2.1 compliance testing for MCP 2025-06-18
- Fixed FastAPI request body consumption bug in authentication flow
  - Request body is now parsed once and stored in `request.state`
  - Prevents 400 Bad Request errors from double-consuming request body
- Added proper OAuth token propagation in test suite
  - Bearer tokens are now stored and reused across test cases
  - Added `_get_auth_headers()` helper for consistent auth header handling

### Specification Compliance
- Fixed MCP specification compliance issues:
  - Corrected camelCase field naming (protocolVersion)
  - Removed unspecified test cases
  - Aligned error responses with specification
- Enhanced session management and URL handling
  - Tests now use session-specific URLs after initialization
  - Fixed session ID extraction and validation logic
- Improved error handling for OAuth challenges
  - 401 responses are now properly handled as OAuth challenges
  - WWW-Authenticate header parsing for metadata discovery
  - Support for `.well-known/oauth-authorization-server` discovery

## Testing
All compliance tests now pass with OAuth enabled:
- ✅ Initialization
- ✅ OAuth Authentication
- ✅ Tools Functionality
- ✅ Error Handling
- ✅ Batch Requests
- ✅ Session Management
- ✅ Protocol Negotiation
- ✅ Ping

## Related Issues
- Fixes #[issue] - OAuth authentication validation failures
- Addresses @Atrawog's feedback about 401 response handling
- Implements @Cliff Hall's note about WWW-Authenticate header flexibility
- Resolves camelCase field naming issues
- Fixes unspecified test cases removal

## Usage
The reference server has OAuth enabled by default. Run compliance tests with:
```bash
python -m mcp_testing.scripts.http_compliance_test --url http://localhost:8088/mcp
```

## Breaking Changes
- Removed non-specification test cases
- Updated field naming to match specification (camelCase)
- OAuth authentication is now required by default